### PR TITLE
Potential fix for code scanning alert no. 79: Uncontrolled data used in path expression

### DIFF
--- a/src/helpers/utils/caches/images.js
+++ b/src/helpers/utils/caches/images.js
@@ -11,7 +11,11 @@ export class ImageCache extends FileCache {
     }
 
     getCacheFilePath(key, extension) {
-        return path.join(this.cacheDir, `${key}${extension}`);
+        const filePath = path.resolve(this.cacheDir, `${key}${extension}`);
+        if (!filePath.startsWith(path.resolve(this.cacheDir))) {
+            throw new Error('Invalid file path');
+        }
+        return filePath;
     }
 
     async saveImage(key, imageBuffer, extension) {


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/79](https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/79)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root cache directory. This will prevent any path traversal attacks.

1. Modify the `getCacheFilePath` method in `ImageCache` to normalize the path and check that it starts with the cache directory.
2. Update the `getImage` method in `ImageCache` to use the modified `getCacheFilePath` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
