### PR TITLE
Potential fix for code scanning alert no. 73: Uncontrolled data used in path expression

### DIFF
--- a/src/helpers/utils/caches/files.js
+++ b/src/helpers/utils/caches/files.js
@@ -15,7 +15,11 @@ export class FileCache {
     }
 
     getCacheFilePath(key) {
-        return path.join(this.cacheDir, `${key}.json`);
+        const filePath = path.resolve(this.cacheDir, `${key}.json`);
+        if (!filePath.startsWith(path.resolve(this.cacheDir))) {
+            throw new Error('Invalid cache key');
+        }
+        return filePath;
     }
 
     async set(key, data) {
@@ -47,9 +51,12 @@ export class FileCache {
 
     async del(key) {
         try {
-            await fs.unlink(this.getCacheFilePath(key));
+            const filePath = this.getCacheFilePath(key);
+            await fs.unlink(filePath);
         } catch (error) {
-            // Ignore deletion errors
+            if (error.message !== 'Invalid cache key') {
+                // Ignore deletion errors
+            }
         }
     }
 

--- a/src/helpers/utils/caches/files.js
+++ b/src/helpers/utils/caches/files.js
@@ -16,7 +16,8 @@ export class FileCache {
 
     getCacheFilePath(key) {
         const filePath = path.resolve(this.cacheDir, `${key}.json`);
-        if (!filePath.startsWith(path.resolve(this.cacheDir))) {
+        const relative = path.relative(this.cacheDir, filePath);
+        if (relative.startsWith('..') || path.isAbsolute(relative)) {
             throw new Error('Invalid cache key');
         }
         return filePath;


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/73](https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/73)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This will prevent any path traversal attempts.

1. Modify the `getCacheFilePath` method to normalize the path and check that it starts with the root folder.
2. Update the `del` method to use the validated path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
