### PR TITLE
Potential fix for code scanning alert no. 46: Database query built from user-controlled sources

### DIFF
--- a/src/models/users.js
+++ b/src/models/users.js
@@ -12,6 +12,10 @@ const cache = new FileCache({
 
 export const getData = async (request) => {
     const { page, limit, search, sort = "asc" } = request;
+    const validSortValues = ["asc", "desc"];
+    if (!validSortValues.includes(sort.toLowerCase())) {
+        throw new Error("Invalid sort value");
+    }
 
     // Create cache key from request parameters
     const cacheKey = `list_${page}_${limit}_${search}_${sort}`;


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/46](https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/46)

To fix the problem, we need to ensure that the `sort` parameter is sanitized and validated before being used in the SQL query. The best way to fix this is to use query parameters or prepared statements to embed the user input into the query string. In this case, we can validate the `sort` parameter to ensure it only contains allowed values ("asc" or "desc") before using it in the query.

1. Validate the `sort` parameter to ensure it only contains "asc" or "desc".
2. Use the validated `sort` parameter in the query construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
