### PR TITLE
Potential fix for code scanning alert no. 59: Uncontrolled data used in path expression

### DIFF
--- a/src/controllers/images.js
+++ b/src/controllers/images.js
@@ -67,7 +67,13 @@ export const getImage = async (req, res) => {
     try {
         const { filename } = req.params;
         const { fm, q, w, h, fit } = req.query;
-        const filePath = path.join(process.cwd(), 'public/uploads/images', filename);
+        const rootDir = path.join(process.cwd(), 'public/uploads/images');
+        const filePath = path.resolve(rootDir, filename);
+
+        // Check if the filePath is within the root directory
+        if (!filePath.startsWith(rootDir)) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
 
         // Create a cache key based on the image parameters
         const cacheKey = `${filename}-w${w || ''}-h${h || ''}-fm${fm || ''}-q${q || ''}-fit${fit || ''}`;


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/59](https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/59)

To fix the problem, we need to ensure that the constructed `filePath` is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. If the path is not within the root directory, we should return an error response.

1. Normalize the `filePath` using `path.resolve` to remove any ".." segments.
2. Check that the normalized path starts with the root directory.
3. If the path is not within the root directory, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
