### PR TITLE
Potential fix for code scanning alert no. 85: Database query built from user-controlled sources

### DIFF
--- a/src/models/users.js
+++ b/src/models/users.js
@@ -20,6 +20,11 @@ export const getData = async (request) => {
 
     const count = await client.query(`SELECT count(id) from public.users`);
     const total = count.rows[0].count || 0;
+    
+    // List of allowed columns for sorting
+    const allowedSortColumns = ["name", "email"];
+    const sortColumn = allowedSortColumns.includes(sort) ? sort : "name";
+
     const query = PAGE.query({
         table: 'public.users',
         selectColumns: ["id", "name", "email", "created_at", "updated_at"],
@@ -38,7 +43,7 @@ export const getData = async (request) => {
         sort: { column: ["name", 'email'], value: '?' },
     });
 
-    const raw = query.replace('?', sort);
+    const raw = query.replace('?', sortColumn);
 
     return await client.query(raw, []).then(
         async result => {


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/85](https://github.com/pphatdev/sample-node-api-migration/security/code-scanning/85)

To fix the problem, we need to ensure that the `sort` parameter is safely embedded into the query string. The best way to achieve this is by using query parameters or prepared statements. However, since the `sort` parameter represents a column name, we need to validate it against a list of allowed column names to prevent SQL injection.

1. Create a list of allowed column names for sorting.
2. Validate the `sort` parameter against this list.
3. If the `sort` parameter is valid, use it directly in the query. Otherwise, use a default column name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
