### PR TITLE
Potential fix for code scanning alert no. 93: Missing rate limiting

### DIFF
--- a/src/routes/images.js
+++ b/src/routes/images.js
@@ -3,6 +3,15 @@ import { authenticateToken } from '../middlewares/authenticate.js'
 import { getImage, create, uploadSingle } from '../controllers/images.js'
 import { Validation } from '../helpers/validator.js'
 import ImageModel from '../models/images.js'
+import rateLimit from 'express-rate-limit'
+
+// Rate limiter: max 100 requests per 15 minutes per IP for image access
+const imageRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+})
 
 export const ROUTE = Router()
 
@@ -11,7 +20,7 @@ ROUTE.get("/", Validation.base.list, async (req, res) => {
     res.send(response)
 })
 
-ROUTE.get("/:folder/:filename", getImage)
+ROUTE.get("/:folder/:filename", imageRateLimiter, getImage)
 
 ROUTE.get("/:id", Validation.base.detail, (req, res) => {
     const { id } = req.params


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/api.sophat.top/security/code-scanning/93](https://github.com/pphatdev/api.sophat.top/security/code-scanning/93)

To fix the missing rate limiting, we should add a rate-limiting middleware to the route that serves images from the file system: `ROUTE.get("/:folder/:filename", getImage)`. The best way to do this in an Express-based app is to use the well-known `express-rate-limit` package. We should import this package, define a rate limiter (e.g., 100 requests per 15 minutes per IP), and apply it specifically to the image-serving route. This avoids affecting other routes unnecessarily and preserves existing functionality. The changes should be made in `src/routes/images.js`:

- Add an import for `express-rate-limit`.
- Define a rate limiter instance.
- Apply the rate limiter as middleware to the `ROUTE.get("/:folder/:filename", getImage)` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
