### PR TITLE
Potential fix for code scanning alert no. 95: Missing rate limiting

### DIFF
--- a/src/routes/password.js
+++ b/src/routes/password.js
@@ -1,12 +1,24 @@
 import { Router } from 'express'
+import rateLimit from 'express-rate-limit'
 import { authenticateToken } from '../middlewares/authenticate.js'
 import { Validation } from '../helpers/validator.js'
 import PasswordModel from '../models/password.js'
 import { Controller } from '../helpers/response/controller.js'
 
+// Rate limiter: max 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+})
+
 const { getData, getDataDetail, updateData } = PasswordModel
 
 export const ROUTE = Router()
+
+// Apply rate limiter to all routes in this router
+ROUTE.use(limiter)
 
 ROUTE.use((req, res, next) => authenticateToken(req, res, next))
 


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/api.sophat.top/security/code-scanning/95](https://github.com/pphatdev/api.sophat.top/security/code-scanning/95)

To fix the missing rate limiting, we should add a rate limiting middleware to the router. The best way is to use the well-known `express-rate-limit` package. We will import it, configure a reasonable rate limit (e.g., 100 requests per 15 minutes per IP), and apply it to the router before the authentication middleware. This ensures all requests to these endpoints are rate-limited, regardless of authentication status. The changes should be made at the top of `src/routes/password.js`: import the package, define the limiter, and add it to the router with `ROUTE.use(limiter)`. This does not change existing functionality, only adds protection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
