### PR TITLE
Potential fix for code scanning alert no. 96: Missing rate limiting

### DIFF
--- a/src/routes/posts.js
+++ b/src/routes/posts.js
@@ -1,11 +1,22 @@
 import { Router } from 'express'
+import rateLimit from 'express-rate-limit'
 import { authenticateToken } from '../middlewares/authenticate.js'
 import { Validation } from '../helpers/validator.js'
 import { getData, getDataDetail, insertData, updateData } from '../models/posts.js'
 import { Controller } from '../helpers/response/controller.js'
 
+// Set up rate limiter: max 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+})
+
 export const ROUTE = Router()
 
+ROUTE.use(limiter)
+
 ROUTE.use((req, res, next) => authenticateToken(req, res, next))
 
 ROUTE.post("/",


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/api.sophat.top/security/code-scanning/96](https://github.com/pphatdev/api.sophat.top/security/code-scanning/96)

To fix the missing rate limiting, we should add a rate limiting middleware to the router. The best way is to use the well-known `express-rate-limit` package, as shown in the recommendation. We will import `express-rate-limit`, configure a rate limiter (e.g., 100 requests per 15 minutes per IP), and apply it to the router using `ROUTE.use(limiter)`. This ensures all endpoints in this router are protected. The changes should be made at the top of `src/routes/posts.js`, adding the import, the limiter definition, and the middleware application before the route definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
