### PR TITLE
Potential fix for code scanning alert no. 97: Missing rate limiting

### DIFF
--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,10 +1,21 @@
 import { Router } from 'express'
+import rateLimit from 'express-rate-limit'
 import { create, update, get , getOnce } from '../controllers/users.js'
 import { authenticateToken } from '../middlewares/authenticate.js'
 import { Validation } from '../helpers/validator.js'
 import { getData } from '../models/users.js'
 
 export const ROUTE = Router()
+
+// Rate limiter: max 100 requests per 15 minutes per IP
+const usersRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+})
+
+ROUTE.use(usersRateLimiter)
 
 ROUTE.post("/", async (req, res) => res.send(await create(req.body)) )
 


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/api.sophat.top/security/code-scanning/97](https://github.com/pphatdev/api.sophat.top/security/code-scanning/97)

To fix the missing rate limiting, we should add a rate-limiting middleware to the router. The best way is to use the well-known `express-rate-limit` package, which is designed for this purpose. We will import `express-rate-limit`, configure a rate limiter (e.g., 100 requests per 15 minutes per IP), and apply it to the router. Since we can only edit the code in `src/routes/users.js`, we will add the import, create the limiter, and use it as middleware before the protected routes. This ensures that all user-related endpoints are protected from abuse without changing their existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
