### PR TITLE
Potential fix for code scanning alert no. 94: Missing rate limiting

### DIFF
--- a/src/routes/images.js
+++ b/src/routes/images.js
@@ -1,11 +1,18 @@
 import { Router } from 'express'
+import rateLimit from 'express-rate-limit'
 import { authenticateToken } from '../middlewares/authenticate.js'
 import { getImage, create, uploadSingle } from '../controllers/images.js'
 import { Validation } from '../helpers/validator.js'
 import ImageModel from '../models/images.js'
 
-export const ROUTE = Router()
+// Set up rate limiter: max 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+})
 
+export const ROUTE = Router()
+ROUTE.use(limiter)
 ROUTE.get("/", Validation.base.list, async (req, res) => {
     const response = await ImageModel.getData(req.query)
     res.send(response)


### PR DESCRIPTION
Potential fix for [https://github.com/pphatdev/api.sophat.top/security/code-scanning/94](https://github.com/pphatdev/api.sophat.top/security/code-scanning/94)

To fix the missing rate limiting issue, we should add a rate-limiting middleware to the router defined in `src/routes/images.js`. The best way to do this is to use the well-known `express-rate-limit` package. We will import `express-rate-limit`, configure a rate limiter (e.g., 100 requests per 15 minutes per IP), and apply it to the router using `ROUTE.use(limiter)`. This will ensure that all requests to the image routes are subject to rate limiting, mitigating the risk of DoS attacks. The changes should be made at the top of the file, before any route definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
